### PR TITLE
Rename serverless service

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@
 #
 # Happy Coding!
 
-service: aws-nodejs # NOTE: update this with your service name
+service: lag-suc # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details


### PR DESCRIPTION
The serverless service was created with the standard name of aws-nodejs

This renames it to lag-suc