### PR TITLE
Add Users Queue

### DIFF
--- a/.serverless_plugins/pseudo-params-test/index.js
+++ b/.serverless_plugins/pseudo-params-test/index.js
@@ -1,0 +1,108 @@
+'use strict';
+
+class ServerlessAWSPseudoParameters {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+    this.hooks = {
+      'after:aws:package:finalize:mergeCustomProviderResources': this.addParameters.bind(this),
+    };
+    this.skipRegionReplace = get(serverless.service, 'custom.pseudoParameters.skipRegionReplace', false)
+  }
+
+  addParameters() {
+
+    const template = this.serverless.service.provider.compiledCloudFormationTemplate;
+    const skipRegionReplace = this.skipRegionReplace;
+    const consoleLog = this.serverless.cli.consoleLog;
+
+    consoleLog(yellow(underline('AWS Pseudo Parameters')));
+
+    if (skipRegionReplace) {
+      consoleLog('Skipping automatic replacement of regions with account region!');
+    }
+
+    // loop through the entire template, and check all (string) properties for any #{AWS::}
+    // reference. If found, replace the value with an Fn::Sub reference
+    Object.keys(template).forEach(identifier => {
+      replaceChildNodes(template[identifier], identifier)
+    });
+
+
+    function isDict(v) {
+      return typeof v === 'object' && v !== null && !(v instanceof Array) && !(v instanceof Date);
+    }
+
+    function isArray(v) {
+      return Object.prototype.toString.call(v) === '[object Array]'
+    }
+
+    function regions() {
+      return [
+        'eu-west-1',
+        'eu-west-2',
+        'us-east-1',
+        'us-east-2',
+        'us-west-2',
+        'ap-south-1',
+        'ap-northeast-2',
+        'ap-southeast-2',
+        'ap-northeast-1',
+        'eu-central-1'
+      ]
+    }
+
+    function containsRegion(v) {
+      return new RegExp(regions().join("|")).test(v);
+    }
+
+    function replaceChildNodes(dictionary, name) {
+      Object.keys(dictionary).forEach((key) => {
+
+        let value = dictionary[key];
+        // if a region name is mentioned, replace it with a reference (unless we are skipping automatic replacements)
+        if (typeof value === 'string' && !skipRegionReplace && containsRegion(value)) {
+          const regionFinder = new RegExp(regions().join("|"));
+          value = value.replace(regionFinder, '#{AWS::Region}');
+        }
+
+        // we only want to possibly replace strings with an Fn::Sub
+        if (typeof value === 'string' && value.search(/#{AWS::([a-zA-Z]+)}/) >= 0) {
+          const aws_regex = /#{AWS::([a-zA-Z]+)}/g;
+
+          dictionary[key] = {
+            "Fn::Sub": value.replace(aws_regex, '${AWS::$1}')
+          };
+
+          // do some fancy logging
+          let m = aws_regex.exec(value);
+          while (m) {
+            consoleLog('AWS Pseudo Parameter: ' + name + '::' + key + ' Replaced ' + yellow(m[1]) + ' with ' + yellow('${AWS::' + m[1] + '}'));
+            m = aws_regex.exec(value);
+          }
+        }
+
+        // dicts and arrays need to be looped through
+        if (isDict(value) || isArray(value)) {
+          dictionary[key] = replaceChildNodes(value, name + '::' + key);
+        }
+
+      });
+      return dictionary;
+    }
+
+    function yellow(str) {
+      return '\u001B[33m' + str + '\u001B[39m';
+    }
+
+    function underline(str) {
+      return '\u001B[4m' + str + '\u001B[24m';
+    }
+  }
+}
+
+function get(obj, path, def) {
+  return path.split('.').filter(Boolean).every(step => !(step && (obj = obj[step]) === undefined)) ? obj : def;
+}
+
+module.exports = ServerlessAWSPseudoParameters;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,6 +4205,11 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "serverless-pseudo-parameters": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-1.4.2.tgz",
+      "integrity": "sha512-4Mlk4qSWuhGeuVMLCb43lf6s2+B2kWhicxl284KX0KBd1eJrifvJOOj4PzKYdig5l4p0/61nNj6QXnR++jG6Iw=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "eslint-plugin-standard": "^3.0.1",
     "mocha": "^5.0.5",
     "nyc": "^11.6.0"
+  },
+  "dependencies": {
+    "serverless-pseudo-parameters": "^1.4.2"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -54,7 +54,11 @@ resources:
             KeyType: HASH
         ProvisionedThroughput:
           ReadCapacityUnits: 5
-          WriteCapacityUnits: 5    
+          WriteCapacityUnits: 5
+    usersQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:service}-usersQueue-${opt:stage}
   
   Outputs:
     UserCacheTableArn:
@@ -67,6 +71,21 @@ resources:
       Value: ${self:custom.TableArns.loanCacheTable}
       Export:
         Name: ${self:service}:${opt:stage}:LoanCacheTableArn
+    UsersQueueName:
+      Description: Name of Users Queue
+      Value: ${self:custom.UsersQueueData.Name}
+      Export:
+        Name: ${self:service}:${opt:stage}:UsersQueueName
+    UsersQueueOwner:
+      Description: AWS Account ID of owner of Users Queue
+      Value: '#{AWS::AccountId}'
+      Export:
+        Name: ${self:service}:${opt:stage}:UsersQueueOwner
+    UsersQueueArn:
+      Description: Arn of Users Queue
+      Value: ${self:custom.UsersQueueData.Arn}
+      Export:
+        Name: ${self:service}:${opt:stage}:UsersQueueArn
 
 custom:
   TableArns:
@@ -74,4 +93,11 @@ custom:
       "Fn::GetAtt": [userCacheTable, Arn]
     loanCacheTable:
       "Fn::GetAtt": [loanCacheTable, Arn]
+  UsersQueueData:
+    Name:
+      "Fn::GetAtt": ["usersQueue", "QueueName"]
+    Arn:
+      "Fn::GetAtt": ["usersQueue", "Arn"]
 
+plugins:
+  - pseudo-params-test


### PR DESCRIPTION
In order to properly handle SNS events, users not present in the cache must have all their loan data updated in bulk using data from Alma.

This is best done by a separate service, so bulk updates to the cache should be queued by these Lambdas.

This adds an SQS message queue to the service for user IDs to be published to, which can then be handled separately and the cache updated from these.