### PR TITLE
Add circleci cache version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-cache-{{ checksum "package.json" }}
+            - dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
+            - dependencies-cache-{{ .Environment.CACHE_VERSION }}
             - dependencies-cache
       - run:
           name: Setup CodeClimate test-reporter
@@ -22,7 +23,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: dependencies-cache-{{ checksum "package.json" }}
+          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
       - run:
           name: Run Tests with Coverage
           command: |
@@ -36,7 +37,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-cache-{{ checksum "package.json" }}
+            - dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
+            - dependencies-cache-{{ .Environment.CACHE_VERSION }}
             - dependencies-cache
       - run:
           name: Install Serverless CLI and dependencies
@@ -46,7 +48,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: dependencies-cache-{{ checksum "package.json" }}
+          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
       - run:
           name: Deploy to Staging environment
           command: |
@@ -70,7 +72,8 @@ jobs:
             EOF
       - restore_cache:
           keys:
-            - dependencies-cache-{{ checksum "package.json" }}
+            - dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
+            - dependencies-cache-{{ .Environment.CACHE_VERSION }}
             - dependencies-cache
       - run:
           name: Install Serverless CLI and dependencies
@@ -80,7 +83,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: dependencies-cache-{{ checksum "package.json" }}
+          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
       - run:
           name: Deploy to Production environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,6 @@ jobs:
           paths:
             - node_modules
           key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
-      - save_cache:
-          paths:
-            - node_modules
-          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Run Tests with Coverage
           command: |
@@ -53,10 +49,6 @@ jobs:
           paths:
             - node_modules
           key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
-      - save_cache:
-          paths:
-            - node_modules
-          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Deploy to Staging environment
           command: |
@@ -92,10 +84,6 @@ jobs:
           paths:
             - node_modules
           key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
-      - save_cache:
-          paths:
-            - node_modules
-          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Deploy to Production environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,10 @@ jobs:
           paths:
             - node_modules
           key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
+      - save_cache:
+          paths:
+            - node_modules
+          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Run Tests with Coverage
           command: |
@@ -49,6 +53,10 @@ jobs:
           paths:
             - node_modules
           key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
+      - save_cache:
+          paths:
+            - node_modules
+          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Deploy to Staging environment
           command: |
@@ -84,6 +92,10 @@ jobs:
           paths:
             - node_modules
           key: dependencies-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "package.json" }}
+      - save_cache:
+          paths:
+            - node_modules
+          key: dependencies-cache-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Deploy to Production environment
           command: |


### PR DESCRIPTION
Some issues have been encountered with dependency caching in circleci, with the cache not building as desired.

This adds the ability to version the cache by setting a CACHE_VERSION environment variable in circleci