### PR TITLE
Validate event module

### DIFF
--- a/src/unsupported-event-error.js
+++ b/src/unsupported-event-error.js
@@ -1,0 +1,8 @@
+class UnsupportedEventError extends Error {
+  constructor (...args) {
+    super(...args)
+    Error.captureStackTrace(this, UnsupportedEventError)
+  }
+}
+
+module.exports = UnsupportedEventError

--- a/src/validate-event.js
+++ b/src/validate-event.js
@@ -1,0 +1,9 @@
+const UnsupportedEventError = require('./unsupported-event-error')
+
+const validateEvent = (event, supportedEvents) => {
+  if (!supportedEvents.includes(event)) {
+    throw new UnsupportedEventError(`Event type ${event} is not supported`)
+  }
+}
+
+module.exports = validateEvent

--- a/test/validate-event-test.js
+++ b/test/validate-event-test.js
@@ -1,0 +1,28 @@
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+chai.should()
+const expect = chai.expect
+
+const UnsupportedEventError = require('../src/unsupported-event-error')
+
+// Module under test
+const validateEvent = require('../src/validate-event')
+
+describe('validate event tests', () => {
+  it('should throw an UnsupportedEvent Error if the event is not in the array', () => {
+    const testEvent = 'NOT_VALID'
+    const testSupported = ['LOAN_CREATED']
+
+    expect(() => validateEvent(testEvent, testSupported)).to.throw(UnsupportedEventError, `Event type ${testEvent} is not supported`)
+  })
+
+  it('should not throw an error if the event is in the array', () => {
+    const testEvent = 'LOAN_CREATED'
+    const testSupported = ['LOAN_CREATED']
+
+    expect(() => validateEvent(testEvent, testSupported)).to.not.throw()
+  })
+})


### PR DESCRIPTION
This adds a module with method to validate that an event is supported by a Lambda, based on a supplied list of supported events.