### PR TITLE
Add Users Queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4373,6 +4373,11 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "serverless-pseudo-parameters": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-1.6.0.tgz",
+      "integrity": "sha512-U0AGzs8qJNAYyp5pntd9W5zKGu3Vxw9YYFgsKpxz/FCNVbSppqMNOjfb2X2mSi6x531QSNs99Twcbeg/lK6hBg=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@lulibrary/lag-alma-utils": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.2.1",
-    "eslint-plugin-chai-friendly": "^0.4.1"
+    "eslint-plugin-chai-friendly": "^0.4.1",
+    "serverless-pseudo-parameters": "^1.6.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -68,6 +68,10 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 5
           WriteCapacityUnits: 5
+    usersQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:service}-usersQueue-${opt:stage}
   
   Outputs:
     UserCacheTableArn:
@@ -85,6 +89,21 @@ resources:
       Value: ${self:custom.TableArns.requestCacheTable}
       Export:
         Name: ${self:service}:${opt:stage}:RequestCacheTableArn
+    UsersQueueName:
+      Description: Name of Users Queue
+      Value: ${self:custom.UsersQueueData.Name}
+      Export:
+        Name: ${self:service}:${opt:stage}:UsersQueueName
+    UsersQueueOwner:
+      Description: AWS Account ID of owner of Users Queue
+      Value: '#{AWS::AccountId}'
+      Export:
+        Name: ${self:service}:${opt:stage}:UsersQueueOwner
+    UsersQueueArn:
+      Description: Arn of Users Queue
+      Value: ${self:custom.UsersQueueData.Arn}
+      Export:
+        Name: ${self:service}:${opt:stage}:UsersQueueArn
 
 custom:
   TableArns:
@@ -94,4 +113,7 @@ custom:
       "Fn::GetAtt": [loanCacheTable, Arn]
     requestCacheTable:
       "Fn::GetAtt": [requestCacheTable, Arn]
+
+plugins:
+  - serverless-pseudo-parameters
 


### PR DESCRIPTION
This adds the definition for the SQS Users Queue to the serverless.yml file, so user IDs can be pushed to the queue for bulk updating.