### PR TITLE
Fix serverless.yml config error

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -113,6 +113,11 @@ custom:
       "Fn::GetAtt": [loanCacheTable, Arn]
     requestCacheTable:
       "Fn::GetAtt": [requestCacheTable, Arn]
+  UsersQueueData:
+    Name:
+      "Fn::GetAtt": ["usersQueue", "QueueName"]
+    Arn:
+      "Fn::GetAtt": ["usersQueue", "Arn"]
 
 plugins:
   - serverless-pseudo-parameters


### PR DESCRIPTION
This fixes an issue in serverless.yml introduced by #22, where custom variables that did not exist were referenced.

This fixes the issue, and has been tested working by deploying to the sandbox AWS account.