### PR TITLE
Change Users Queue name

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -71,7 +71,7 @@ resources:
     usersQueue:
       Type: AWS::SQS::Queue
       Properties:
-        QueueName: ${self:service}-usersQueue-${opt:stage}
+        QueueName: ${self:service}-${opt:stage}-usersQueue
   
   Outputs:
     UserCacheTableArn:


### PR DESCRIPTION
This changes the name of the Users Queue in serverless.yml to match the format defined in Terraform