### PR TITLE
Add Lambda IAM Roles

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,6 +22,22 @@ provider:
   runtime: nodejs6.10
   region: ${opt:region}
   stage: ${opt:stage}
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - sqs:SendMessage
+        - sqs:GetQueueURL
+      Resource: ${self:custom.UsersQueueData.Arn}
+    - Effect: Allow
+      Action:
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+        - dynamodb:DeleteItem
+        - dynamodb:DescribeTable
+      Resource:
+        - ${self:custom.TableArns.userCacheTable}
+        - ${self:custom.TableArns.loanCacheTable}
+        - ${self:custom.TableArns.requestCacheTable}
 
 functions:
   LoanUpdated: # Handles SNS events of type LOAN_CREATED, LOAN_DUE_DATE and LOAN_RETURNED


### PR DESCRIPTION
This adds IAM roles to the `LoanUpdated` and `LoanReturned` Lambdas to allow them to read/write from/to the DynamoDB cache, and to send messages to the Users SQS Queue