### PR TITLE
Request updated handler

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -66,6 +66,19 @@ functions:
       UsersQueueName: ${self:custom.UsersQueueData.Name}
       UsersQueueOwner: ${self:custom.UsersQueueData.Owner}
       UsersQueueURL: ${self:custom.UsersQueueData.URL}
+  RequestUpdated: # Handles SNS events of type LOAN_CREATED, LOAN_DUE_DATE and LOAN_RETURNED
+    handler: src/request-updated/handler.handle
+    events:
+      - sns:
+          arn: ${self:custom.TopicArns.${opt:stage}.RequestCreated}
+      - sns:
+          arn: ${self:custom.TopicArns.${opt:stage}.RequestPlacedOnShelf}
+    environment:
+      UserCacheTableName: ${self:custom.TableNames.userCacheTable}
+      RequestCacheTableName: ${self:custom.TableNames.requestCacheTable}
+      UsersQueueName: ${self:custom.UsersQueueData.Name}
+      UsersQueueOwner: ${self:custom.UsersQueueData.Owner}
+      UsersQueueURL: ${self:custom.UsersQueueData.URL}
 
 resources:
   Resources:
@@ -149,11 +162,15 @@ custom:
       LoanDueDate: ${env:LOAN_DUE_DATE_TOPIC_ARN_STG}
       LoanReturned: ${env:LOAN_RETURNED_TOPIC_ARN_STG}
       LoanRenewed: ${env:LOAN_RENEWED_TOPIC_ARN_STG}
+      RequestCreated: ${env:REQUEST_CREATED_TOPIC_ARN_STG}
+      RequestPlacedOnShelf: ${env:LOAN_PLACED_ON_SHELF_TOPIC_ARN_STG}
     prod:
       LoanCreated: ${env:LOAN_CREATED_TOPIC_ARN_PROD}
       LoanDueDate: ${env:LOAN_DUE_DATE_TOPIC_ARN_PROD}
       LoanReturned: ${env:LOAN_RETURNED_TOPIC_ARN_PROD}
       LoanRenewed: ${env:LOAN_RENEWED_TOPIC_ARN_PROD}
+      RequestCreated: ${env:REQUEST_CREATED_TOPIC_ARN_PROD}
+      RequestPlacedOnShelf: ${env:LOAN_PLACED_ON_SHELF_TOPIC_ARN_PROD}
   TableArns:
     userCacheTable:
       "Fn::GetAtt": [userCacheTable, Arn]
@@ -166,6 +183,8 @@ custom:
       Ref: userCacheTable
     loanCacheTable:
       Ref: loanCacheTable
+    requestCacheTable:
+      Ref: requestCacheTable
   UsersQueueData:
     Name:
       "Fn::GetAtt": ["usersQueue", "QueueName"]

--- a/src/cache.js
+++ b/src/cache.js
@@ -86,6 +86,10 @@ class Cache {
     return this.models.LoanModel.delete(loanID)
   }
 
+  updateRequest (userRequest) {
+    return new this.models.RequestModel(userRequest).save()
+  }
+
   handleLoanReturned (itemLoan) {
     return Promise.all([
       this.deleteLoan(itemLoan.loan_id),
@@ -97,6 +101,13 @@ class Cache {
     return Promise.all([
       this.updateLoan(itemLoan),
       this.addLoanToUser(itemLoan.user_id, itemLoan.loan_id)
+    ])
+  }
+
+  handleRequestUpdate (userRequest) {
+    return Promise.all([
+      this.updateRequest(userRequest),
+      this.addRequestToUser(userRequest.user_primary_id, userRequest.request_id)
     ])
   }
 }

--- a/src/request-updated/handler.js
+++ b/src/request-updated/handler.js
@@ -1,0 +1,17 @@
+const extractMessageData = require('../extract-message-data')
+const almaCache = require('../cache-from-env')
+
+module.exports.handle = (event, context, callback) => {
+  try {
+    const requestData = extractMessageData(event)
+    almaCache.handleRequestUpdate(requestData.user_request)
+      .then(() => callback(null, generateSuccessMessage(requestData.user_request.request_id)))
+      .catch(callback)
+  } catch (e) {
+    callback(e)
+  }
+}
+
+const generateSuccessMessage = (id) => {
+  return `Request ${id} successfully updated in cache`
+}

--- a/test/dynamodb-local.js
+++ b/test/dynamodb-local.js
@@ -63,6 +63,7 @@ const testLoanTable = `loanTable_${uuid()}`
 const testRequestTable = `requestTable_${uuid()}`
 
 before(function () {
+  process.env.RequestCacheTableName = testRequestTable
   process.env.LoanCacheTableName = testLoanTable
   process.env.UserCacheTableName = testUserTable
 
@@ -85,13 +86,14 @@ before(function () {
         },
         {
           name: testRequestTable,
-          key: 'loan_id'
+          key: 'request_id'
         }
       ])
     })
 })
 
 after(() => {
+  delete process.env.RequestCacheTableName
   delete process.env.LoanCacheTableName
   delete process.env.UserCacheTableName
 

--- a/test/request-updated/handler-test.js
+++ b/test/request-updated/handler-test.js
@@ -1,0 +1,294 @@
+const AWS_MOCK = require('aws-sdk-mock')
+const AWS = require('aws-sdk')
+
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+chai.should()
+
+const uuid = require('uuid/v4')
+
+// DynamoDB
+const dynamoose = require('dynamoose')
+dynamoose.local()
+dynamoose.AWS.config.update({
+  region: 'eu-west-2'
+})
+const docClient = new AWS.DynamoDB.DocumentClient({ region: 'eu-west-2', endpoint: 'http://127.0.0.1:8000' })
+
+const Schemas = require('@lulibrary/lag-alma-utils')
+const Queue = require('@lulibrary/lag-utils/src/queue')
+
+const Cache = require('../../src/cache')
+
+// Module under test
+let RequestUpdatedHandler
+
+// Test info
+let UserModel
+let RequestModel
+
+let testRequestTable, testUserTable
+
+const testQueueName = 'userQueueName'
+const testQueueOwner = 'userQueueOwner'
+const testQueueUrl = 'userQueueURL'
+
+let mocks = []
+
+describe('Request updated lambda handler tests', () => {
+  describe('end to end tests', () => {
+    before(() => {
+      testRequestTable = process.env.RequestCacheTableName
+      testUserTable = process.env.UserCacheTableName
+
+      console.log(process.env.RequestCacheTableName)
+
+      UserModel = Schemas.UserSchema(testUserTable)
+      RequestModel = Schemas.RequestSchema(testRequestTable)
+      process.env.UsersQueueName = testQueueName
+      process.env.UsersQueueOwner = testQueueOwner
+
+      RequestUpdatedHandler = require('../../src/request-updated/handler')
+    })
+
+    afterEach(() => {
+      sandbox.restore()
+      mocks.forEach(mock => AWS_MOCK.restore(mock))
+      mocks = []
+    })
+
+    after(() => {
+      delete process.env.UsersQueueName
+      delete process.env.UsersQueueOwner
+    })
+
+    it('should callback with an error if extractMessageData throws an error', () => {
+      return new Promise((resolve, reject) => {
+        RequestUpdatedHandler.handle({}, null, (err, data) => {
+          err ? reject(err) : resolve(data)
+        })
+      }).should.eventually.be.rejectedWith('Could not parse SNS message')
+    })
+
+    it('should create a new request record in the database', () => {
+      let testRequestId = uuid()
+      let testUserId = uuid()
+      const testTitle = uuid()
+
+      sandbox.stub(Cache.prototype, 'addRequestToUser').resolves(true)
+
+      const requestData = {
+        user_request: {
+          user_primary_id: testUserId,
+          request_id: testRequestId,
+          title: testTitle
+        }
+      }
+
+      const input = {
+        Records: [{
+          Sns: {
+            Message: JSON.stringify(requestData)
+          }
+        }]
+      }
+
+      const runTest = () => {
+        return new Promise((resolve, reject) => {
+          RequestUpdatedHandler.handle(input, null, (err, data) => {
+            return err ? reject(err) : resolve(data)
+          })
+        })
+          .then(() => {
+            return checkExists()
+          })
+      }
+
+      const checkExists = () => {
+        return docClient.get({
+          TableName: testRequestTable,
+          Key: {
+            request_id: testRequestId
+          }
+        }).promise()
+          .then((data) => {
+            data.Item.should.deep.equal({
+              user_primary_id: testUserId,
+              request_id: testRequestId,
+              title: testTitle
+            })
+          })
+      }
+
+      return RequestModel.delete(testRequestId)
+        .then(() => {
+          return runTest()
+        })
+    })
+
+    it('should update a user record if it already exists', () => {
+      sandbox.stub(Date, 'now').returns(0)
+
+      let testRequestId = uuid()
+      let testUserId = uuid()
+      const testTitle = uuid()
+
+      const requestData = {
+        user_request: {
+          user_primary_id: testUserId,
+          request_id: testRequestId,
+          title: testTitle
+        }
+      }
+
+      const input = {
+        Records: [{
+          Sns: {
+            Message: JSON.stringify(requestData)
+          }
+        }]
+      }
+
+      const runTest = () => {
+        return new Promise((resolve, reject) => {
+          RequestUpdatedHandler.handle(input, null, (err, data) => {
+            return err ? reject(err) : resolve(data)
+          })
+        })
+          .then(() => {
+            return checkUpdated()
+          })
+      }
+
+      const checkUpdated = () => {
+        return docClient.get({
+          TableName: testUserTable,
+          Key: {
+            primary_id: testUserId
+          }
+        }).promise()
+          .then((data) => {
+            data.Item.should.deep.equal({
+              primary_id: testUserId,
+              request_ids: [testRequestId],
+              loan_ids: [],
+              expiry_date: 7200
+            })
+          })
+      }
+
+      return UserModel.create({
+        primary_id: testUserId,
+        request_ids: [],
+        loan_ids: []
+      })
+        .then(() => {
+          return runTest()
+        })
+    })
+
+    it('should overwrite a request record in the database', () => {
+      let testRequestId = uuid()
+      let testUserId = uuid()
+      const testTitle = uuid()
+
+      sandbox.stub(Cache.prototype, 'addRequestToUser').resolves(true)
+
+      const requestData = {
+        user_request: {
+          user_primary_id: testUserId,
+          request_id: testRequestId,
+          title: testTitle
+        }
+      }
+
+      const input = {
+        Records: [{
+          Sns: {
+            Message: JSON.stringify(requestData)
+          }
+        }]
+      }
+
+      const runTest = () => {
+        return new Promise((resolve, reject) => {
+          RequestUpdatedHandler.handle(input, null, (err, data) => {
+            return err ? reject(err) : resolve(data)
+          })
+        })
+          .then(() => {
+            return checkExists()
+          })
+      }
+
+      const checkExists = () => {
+        return docClient.get({
+          TableName: testRequestTable,
+          Key: {
+            request_id: testRequestId
+          }
+        }).promise()
+          .then((data) => {
+            data.Item.should.deep.equal({
+              user_primary_id: testUserId,
+              request_id: testRequestId,
+              title: testTitle
+            })
+          })
+      }
+
+      const inititalTestRequest = {
+        request_id: testRequestId,
+        user_primary_id: testUserId,
+        title: `an-old-incorrect-title-${uuid()}`,
+        author: `an-old-incorrect-author-${uuid()}`
+      }
+
+      return RequestModel.create(inititalTestRequest)
+        .then(() => {
+          return runTest()
+        })
+    })
+
+    it('should send the user ID to SQS if the user does not exist', () => {
+      let testRequestId = uuid()
+      let testUserId = uuid()
+      const testTitle = uuid()
+
+      sandbox.stub(Cache.prototype, 'updateRequest').resolves(true)
+      const sendMessageStub = sandbox.stub(Queue.prototype, 'sendMessage')
+
+      const requestData = {
+        user_request: {
+          user_primary_id: testUserId,
+          request_id: testRequestId,
+          title: testTitle,
+          due_date: '1970-01-01T00:00:01'
+        }
+      }
+
+      const input = {
+        Records: [{
+          Sns: {
+            Message: JSON.stringify(requestData)
+          }
+        }]
+      }
+
+      return new Promise((resolve, reject) => {
+        RequestUpdatedHandler.handle(input, null, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+        .then(() => {
+          sendMessageStub.should.have.been.calledWith(testUserId)
+        })
+    })
+  })
+})


### PR DESCRIPTION
This adds a `request-updated` handler, for handling messages of type `REQUEST_CREATED` and `REQUEST_PLACED_ON_SHELF`.
This handler writes the Request data to the Request cache, and  either adds the request ID to the corresponding User record if the User record exists, or sends the User ID to the Users queue if it does not.