### PR TITLE
Request Closed Handler

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -55,7 +55,7 @@ functions:
       UsersQueueName: ${self:custom.UsersQueueData.Name}
       UsersQueueOwner: ${self:custom.UsersQueueData.Owner}
       UsersQueueURL: ${self:custom.UsersQueueData.URL}
-  LoanReturned:
+  LoanReturned: # Handles SNS events of type LOAN_RETURNED
     handler: src/loan-returned/handler.handle
     events:
       - sns:
@@ -66,13 +66,26 @@ functions:
       UsersQueueName: ${self:custom.UsersQueueData.Name}
       UsersQueueOwner: ${self:custom.UsersQueueData.Owner}
       UsersQueueURL: ${self:custom.UsersQueueData.URL}
-  RequestUpdated: # Handles SNS events of type LOAN_CREATED, LOAN_DUE_DATE and LOAN_RETURNED
+  RequestUpdated: # Handles SNS events of type REQUEST_CREATED, REQUEST_PLACED_ON_SHELF
     handler: src/request-updated/handler.handle
     events:
       - sns:
           arn: ${self:custom.TopicArns.${opt:stage}.RequestCreated}
       - sns:
           arn: ${self:custom.TopicArns.${opt:stage}.RequestPlacedOnShelf}
+    environment:
+      UserCacheTableName: ${self:custom.TableNames.userCacheTable}
+      RequestCacheTableName: ${self:custom.TableNames.requestCacheTable}
+      UsersQueueName: ${self:custom.UsersQueueData.Name}
+      UsersQueueOwner: ${self:custom.UsersQueueData.Owner}
+      UsersQueueURL: ${self:custom.UsersQueueData.URL}
+  RequestClosed: # Handles SNS events of type REQUEST_CLOSED and REQUEST_CANCELED
+    handler: src/request-closed/handler.handle
+    events:
+      - sns:
+          arn: ${self:custom.TopicArns.${opt:stage}.RequestClosed}
+      - sns:
+          arn: ${self:custom.TopicArns.${opt:stage}.RequestCanceled}
     environment:
       UserCacheTableName: ${self:custom.TableNames.userCacheTable}
       RequestCacheTableName: ${self:custom.TableNames.requestCacheTable}
@@ -172,6 +185,8 @@ custom:
       LoanRenewed: ${env:LOAN_RENEWED_TOPIC_ARN_STG}
       RequestCreated: ${env:REQUEST_CREATED_TOPIC_ARN_STG}
       RequestPlacedOnShelf: ${env:LOAN_PLACED_ON_SHELF_TOPIC_ARN_STG}
+      RequestClosed: ${env:REQUEST_CLOSED_TOPIC_ARN_STG}
+      RequestCanceled: ${env:LOAN_CANCELED_TOPIC_ARN_STG}
     prod:
       LoanCreated: ${env:LOAN_CREATED_TOPIC_ARN_PROD}
       LoanDueDate: ${env:LOAN_DUE_DATE_TOPIC_ARN_PROD}
@@ -179,6 +194,8 @@ custom:
       LoanRenewed: ${env:LOAN_RENEWED_TOPIC_ARN_PROD}
       RequestCreated: ${env:REQUEST_CREATED_TOPIC_ARN_PROD}
       RequestPlacedOnShelf: ${env:LOAN_PLACED_ON_SHELF_TOPIC_ARN_PROD}
+      RequestClosed: ${env:REQUEST_CLOSED_TOPIC_ARN_PROD}
+      RequestCanceled: ${env:LOAN_CANCELED_TOPIC_ARN_PROD}
   TableArns:
     userCacheTable:
       "Fn::GetAtt": [userCacheTable, Arn]

--- a/src/request-closed/handler.js
+++ b/src/request-closed/handler.js
@@ -1,0 +1,25 @@
+const extractMessageData = require('../extract-message-data')
+const CacheRequest = require('../cache-request')
+const CacheUser = require('../cache-user')
+
+module.exports.handle = (event, context, callback) => {
+  try {
+    const requestData = extractMessageData(event)
+    Promise.all([
+      new CacheRequest().delete(requestData.user_request.request_id),
+      new CacheUser().deleteRequest(requestData.user_request.user_primary_id, requestData.user_request.request_id)
+    ])
+      .then(() => {
+        callback(null, generateSuccessMessage(requestData.user_request.request_id))
+      })
+      .catch(e => {
+        callback(new Error(`Failed to delete Request ${requestData.user_request.request_id} for User ${requestData.user_request.user_primary_id} in Cache`))
+      })
+  } catch (e) {
+    callback(e)
+  }
+}
+
+const generateSuccessMessage = (id) => {
+  return `Request ${id} successfully deleted from cache`
+}

--- a/test/request-closed/handler-test.js
+++ b/test/request-closed/handler-test.js
@@ -1,0 +1,255 @@
+const AWS_MOCK = require('aws-sdk-mock')
+
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(sinonChai)
+chai.use(chaiAsPromised)
+chai.should()
+
+const uuid = require('uuid/v4')
+const _pick = require('lodash.pick')
+
+// DynamoDB
+const dynamoose = require('dynamoose')
+dynamoose.local()
+dynamoose.AWS.config.update({
+  region: 'eu-west-2'
+})
+const AWS = require('aws-sdk')
+
+const docClient = new AWS.DynamoDB.DocumentClient({ region: 'eu-west-2', endpoint: 'http://127.0.0.1:8000' })
+
+const Schemas = require('@lulibrary/lag-alma-utils')
+const Queue = require('@lulibrary/lag-utils/src/queue')
+
+// Module under test
+let RequestClosedHandler
+
+// Test info
+let UserModel
+let RequestModel
+
+let testLoanTable, testUserTable
+const testQueueName = 'userQueueName'
+const testQueueOwner = 'userQueueOwner'
+const testQueueUrl = 'userQueueURL'
+
+let mocks = []
+
+const handle = (event, ctx) => new Promise((resolve, reject) => {
+  RequestClosedHandler.handle(event, ctx, (err, data) => {
+    return err ? reject(err) : resolve(data)
+  })
+})
+
+describe('Loan returned lambda handler tests', () => {
+  describe('end to end tests', () => {
+    before(() => {
+      testLoanTable = process.env.RequestCacheTableName
+      testUserTable = process.env.UserCacheTableName
+
+      UserModel = Schemas.UserSchema(testUserTable)
+      RequestModel = Schemas.RequestSchema(testLoanTable)
+      process.env.UsersQueueName = testQueueName
+      process.env.UsersQueueOwner = testQueueOwner
+
+      RequestClosedHandler = require('../../src/request-closed/handler')
+    })
+
+    afterEach(() => {
+      sandbox.restore()
+      mocks.forEach(mock => AWS_MOCK.restore(mock))
+      mocks = []
+    })
+
+    after(() => {
+      delete process.env.UsersQueueName
+      delete process.env.UsersQueueOwner
+    })
+
+    it('should callback with an error if extractMessageData throws an error', () => {
+      handle({}, null).should.eventually.be.rejectedWith('Could not parse SNS message')
+    })
+
+    it('should delete an existing loan record from the database', () => {
+      let testRequestID = uuid()
+      let testUserID = uuid()
+      const testTitle = uuid()
+
+      // sandbox.stub(Cache.prototype, 'deleteLoanFromUser').resolves(true)
+      sandbox.stub(Queue.prototype, 'sendMessage').resolves()
+
+      const requestData = {
+        user_request: {
+          user_primary_id: testUserID,
+          request_id: testRequestID,
+          title: testTitle,
+          due_date: '1970-01-01T00:00:01'
+        }
+      }
+
+      const input = {
+        Records: [{
+          Sns: {
+            Message: JSON.stringify(requestData)
+          }
+        }]
+      }
+
+      const runTest = () => {
+        handle(input, null)
+          .then(() => {
+            return checkExists()
+          })
+      }
+
+      const checkExists = () => {
+        return docClient.get({
+          TableName: testLoanTable,
+          Key: {
+            request_id: testRequestID
+          }
+        }).promise()
+          .then((data) => {
+            data.should.deep.equal({})
+          })
+      }
+
+      const existing = {
+        user_id: testUserID,
+        request_id: testRequestID,
+        title: testTitle,
+        due_date: '1970-01-01T00:00:01'
+      }
+
+      return RequestModel.create(existing)
+        .then(() => {
+          return runTest()
+        })
+    })
+
+    it('should update a user record if it already exists', () => {
+      sandbox.stub(Date, 'now').returns(0)
+
+      let testRequestID = uuid()
+      let testUserID = uuid()
+      const testTitle = uuid()
+
+      // sandbox.stub(Cache.prototype, 'deleteLoan').resolves(true)
+
+      const requestData = {
+        user_request: {
+          user_primary_id: testUserID,
+          request_id: testRequestID,
+          title: testTitle,
+          due_date: '1970-01-01T00:00:01'
+        }
+      }
+
+      const input = {
+        Records: [{
+          Sns: {
+            Message: JSON.stringify(requestData)
+          }
+        }]
+      }
+
+      const runTest = () => {
+        handle(input, null)
+          .then(() => {
+            return checkUpdated()
+          })
+      }
+
+      const checkUpdated = () => {
+        return docClient.get({
+          TableName: testUserTable,
+          Key: {
+            primary_id: testUserID
+          }
+        }).promise()
+          .then((data) => {
+            _pick(data.Item, [
+              'primary_id',
+              'request_ids',
+              'expiry_date'
+            ]).should.deep.equal({
+              primary_id: testUserID,
+              request_ids: [],
+              expiry_date: 7200
+            })
+          })
+      }
+
+      return UserModel.create({
+        primary_id: testUserID,
+        request_ids: [testRequestID]
+      })
+        .then(() => {
+          return runTest()
+        })
+    })
+
+    it('should send the user ID to SQS if the user does not exist', () => {
+      let testRequestID = uuid()
+      let testUserID = uuid()
+      const testTitle = uuid()
+
+      // sandbox.stub(Cache.prototype, 'deleteLoan').resolves(true)
+      const sendMessageStub = sandbox.stub(Queue.prototype, 'sendMessage')
+
+      const requestData = {
+        user_request: {
+          user_primary_id: testUserID,
+          request_id: testRequestID,
+          title: testTitle,
+          due_date: '1970-01-01T00:00:01'
+        }
+      }
+
+      const input = {
+        Records: [{
+          Sns: {
+            Message: JSON.stringify(requestData)
+          }
+        }]
+      }
+
+      handle(input, null)
+        .then(() => {
+          sendMessageStub.should.have.been.calledWith(testUserID)
+        })
+    })
+
+    it('should callback with an error if the Cache fails to update', () => {
+      const testUserID = uuid()
+      const testRequestID = uuid()
+      const testTitle = uuid()
+
+      const sendMessageStub = sandbox.stub(Queue.prototype, 'sendMessage')
+
+      const requestData = {
+        user_request: {
+          user_primary_id: testUserID,
+          title: testTitle,
+          due_date: '1970-01-01T00:00:01'
+        }
+      }
+
+      const input = {
+        Records: [{
+          Sns: {
+            Message: JSON.stringify(requestData)
+          }
+        }]
+      }
+
+      return handle(input, null)
+        .should.eventually.be.rejectedWith(`Failed to delete Request ${undefined} for User ${testUserID} in Cache`)
+    })
+  })
+})

--- a/test/request-closed/handler-test.js
+++ b/test/request-closed/handler-test.js
@@ -33,7 +33,7 @@ let RequestClosedHandler
 let UserModel
 let RequestModel
 
-let testLoanTable, testUserTable
+let testRequestTable, testUserTable
 const testQueueName = 'userQueueName'
 const testQueueOwner = 'userQueueOwner'
 const testQueueUrl = 'userQueueURL'
@@ -49,11 +49,11 @@ const handle = (event, ctx) => new Promise((resolve, reject) => {
 describe('Loan returned lambda handler tests', () => {
   describe('end to end tests', () => {
     before(() => {
-      testLoanTable = process.env.RequestCacheTableName
+      testRequestTable = process.env.RequestCacheTableName
       testUserTable = process.env.UserCacheTableName
 
       UserModel = Schemas.UserSchema(testUserTable)
-      RequestModel = Schemas.RequestSchema(testLoanTable)
+      RequestModel = Schemas.RequestSchema(testRequestTable)
       process.env.UsersQueueName = testQueueName
       process.env.UsersQueueOwner = testQueueOwner
 
@@ -72,7 +72,7 @@ describe('Loan returned lambda handler tests', () => {
     })
 
     it('should callback with an error if extractMessageData throws an error', () => {
-      handle({}, null).should.eventually.be.rejectedWith('Could not parse SNS message')
+      return handle({}, null).should.eventually.be.rejectedWith('Could not parse SNS message')
     })
 
     it('should delete an existing loan record from the database', () => {
@@ -101,7 +101,7 @@ describe('Loan returned lambda handler tests', () => {
       }
 
       const runTest = () => {
-        handle(input, null)
+        return handle(input, null)
           .then(() => {
             return checkExists()
           })
@@ -109,7 +109,7 @@ describe('Loan returned lambda handler tests', () => {
 
       const checkExists = () => {
         return docClient.get({
-          TableName: testLoanTable,
+          TableName: testRequestTable,
           Key: {
             request_id: testRequestID
           }
@@ -159,7 +159,7 @@ describe('Loan returned lambda handler tests', () => {
       }
 
       const runTest = () => {
-        handle(input, null)
+        return handle(input, null)
           .then(() => {
             return checkUpdated()
           })
@@ -219,7 +219,7 @@ describe('Loan returned lambda handler tests', () => {
         }]
       }
 
-      handle(input, null)
+      return handle(input, null)
         .then(() => {
           sendMessageStub.should.have.been.calledWith(testUserID)
         })


### PR DESCRIPTION
This adds a `request-closed` handler Lambda to the service, to handle SNS messages of type `REQUEST_CLOSED` and `REQUEST_CANCELED`.

The Lambda will delete a request with matching `request_id` from the Cache, and will either delete the `request_id` from the the corresponding User record, or send the User ID to the users queue if the User does not exist in the Cache.