### PR TITLE
Update Package Versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "dependencies": {
     "@lulibrary/lag-alma-utils": {
-      "version": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#0b9d59812400a7b45e78c4aafad219eeb5a82cef",
-      "from": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.5.2",
+      "version": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#5f8e7131055485774522c6dc10c86476df5aa9c1",
+      "from": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.7.0",
       "requires": {
         "dynamoose": "^0.8.7",
         "lodash.chunk": "^4.2.0",
@@ -14,11 +14,12 @@
       }
     },
     "@lulibrary/lag-utils": {
-      "version": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#978e4995bada3d86507ec0fcc4d75e6cb3b179c3",
-      "from": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.3",
+      "version": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#ff141647c845a8f71804ee265366cba99c475fc9",
+      "from": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.4.0",
       "requires": {
         "aws-sdk": "^2.223.1",
-        "eslint-plugin-mocha": "^5.0.0"
+        "eslint-plugin-mocha": "^5.0.0",
+        "lodash.merge": "^4.6.1"
       }
     },
     "@sinonjs/formatio": {
@@ -1208,6 +1209,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.pick": {
       "version": "4.4.0",
@@ -4493,7 +4499,8 @@
     "serverless-pseudo-parameters": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-1.6.0.tgz",
-      "integrity": "sha512-U0AGzs8qJNAYyp5pntd9W5zKGu3Vxw9YYFgsKpxz/FCNVbSppqMNOjfb2X2mSi6x531QSNs99Twcbeg/lK6hBg=="
+      "integrity": "sha512-U0AGzs8qJNAYyp5pntd9W5zKGu3Vxw9YYFgsKpxz/FCNVbSppqMNOjfb2X2mSi6x531QSNs99Twcbeg/lK6hBg==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "mocha": "^5.0.5",
     "nyc": "^11.6.0",
     "rewire": "^4.0.1",
+    "serverless-pseudo-parameters": "^1.6.0",
     "sinon": "^5.0.2",
     "sinon-chai": "^3.0.0",
     "uuid": "^3.2.1"
   },
   "dependencies": {
-    "@lulibrary/lag-alma-utils": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.5.2",
-    "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.3.3",
-    "serverless-pseudo-parameters": "^1.6.0"
+    "@lulibrary/lag-alma-utils": "git+ssh://git@github.com/lulibrary/LAG-Alma-Utils.git#v0.7.0",
+    "@lulibrary/lag-utils": "git+ssh://git@github.com/lulibrary/LAG-Utils.git#v0.4.0"
   }
 }

--- a/src/cache-user.js
+++ b/src/cache-user.js
@@ -1,5 +1,5 @@
 const Schemas = require('@lulibrary/lag-alma-utils')
-const Queue = require('@lulibrary/lag-utils/src/queue')
+const { Queue } = require('@lulibrary/lag-utils')
 
 const CacheItem = require('./cache-item')
 


### PR DESCRIPTION
This updates the version of the `LAG-Utils` and `LAG-Alma-Utils` packages to the latest releases published on github. The main change from this is for all records written to the cache to force the user ID fields to be lower case.